### PR TITLE
Fix column scrolling and add column button positioning

### DIFF
--- a/client/components/column-config/column-config-row.tsx
+++ b/client/components/column-config/column-config-row.tsx
@@ -63,8 +63,13 @@ export const ColumnConfigRow: React.FC<ColumnConfigRowProps> = ({
           onChange={(checked) => {
             if (!checked) {
               updateConfig({ filterable: checked, filterValues: [] })
+            } else {
+              updateConfig({ filterable: checked })
+              onFilterToggle?.()
             }
-            updateConfig({ filterable: checked })
+            if (!checked) {
+              updateConfig({ filterable: checked })
+            }
           }}
           label="Filterable"
         />

--- a/client/components/column-config/column-config-row.tsx
+++ b/client/components/column-config/column-config-row.tsx
@@ -23,6 +23,7 @@ export const ColumnConfigRow: React.FC<ColumnConfigRowProps> = ({
   columnTypes,
   updateConfig,
   isEdit,
+  columnId,
 }) => {
   return (
     <ResponsiveFormRow>

--- a/client/components/column-config/column-config-row.tsx
+++ b/client/components/column-config/column-config-row.tsx
@@ -1,14 +1,14 @@
-import React from 'react';
+import React from "react";
 import {
   ResponsiveFormRow,
   ResponsiveFormGroup,
   ResponsiveFormGroupToggle,
   FormLabel,
   FormInput,
-  FormSelect
-} from './style';
-import { Toggle } from './toggle';
-import { ColumnConfig } from './types';
+  FormSelect,
+} from "./style";
+import { Toggle } from "./toggle";
+import { ColumnConfig } from "./types";
 
 interface ColumnConfigRowProps {
   config: ColumnConfig;
@@ -31,8 +31,8 @@ export const ColumnConfigRow: React.FC<ColumnConfigRowProps> = ({
         <FormLabel htmlFor={`column-name-${columnId}`}>Column Name</FormLabel>
         <FormInput
           id={`column-name-${columnId}`}
-          type='text'
-          value={(config?.label || '')}
+          type="text"
+          value={config?.label || ""}
           onChange={(e) => updateConfig({ label: e.target.value })}
           placeholder="Enter column name"
         />
@@ -42,9 +42,11 @@ export const ColumnConfigRow: React.FC<ColumnConfigRowProps> = ({
         <FormLabel htmlFor={`column-type-${columnId}`}>Column Type</FormLabel>
         <FormSelect
           id={`column-type-${columnId}`}
-          value={(config?.columnType || '')}
+          value={config?.columnType || ""}
           onChange={(e) =>
-            updateConfig({ columnType: e.target.value as ColumnConfig['columnType'] })
+            updateConfig({
+              columnType: e.target.value as ColumnConfig["columnType"],
+            })
           }
           disabled={isEdit}
         >
@@ -59,12 +61,12 @@ export const ColumnConfigRow: React.FC<ColumnConfigRowProps> = ({
       <ResponsiveFormGroupToggle>
         <Toggle
           id={`is-filterable-${columnId}`}
-          checked={(config?.filterable || false)}
+          checked={config?.filterable || false}
           onChange={(checked) => {
             if (!checked) {
-              updateConfig({ filterable: checked, filterValues: [] })
+              updateConfig({ filterable: checked, filterValues: [] });
             } else {
-              updateConfig({ filterable: checked })
+              updateConfig({ filterable: checked });
             }
           }}
           label="Filterable"
@@ -74,7 +76,7 @@ export const ColumnConfigRow: React.FC<ColumnConfigRowProps> = ({
       <ResponsiveFormGroupToggle>
         <Toggle
           id={`is-hidden-${columnId}`}
-          checked={(config?.hidden || false)}
+          checked={config?.hidden || false}
           onChange={(checked) => updateConfig({ hidden: checked })}
           label="Hidden"
         />
@@ -83,7 +85,7 @@ export const ColumnConfigRow: React.FC<ColumnConfigRowProps> = ({
       <ResponsiveFormGroupToggle>
         <Toggle
           id={`is-searchable-${columnId}`}
-          checked={(config?.searchable || false)}
+          checked={config?.searchable || false}
           onChange={(checked) => updateConfig({ searchable: checked })}
           label="Searchable"
         />

--- a/client/components/column-config/column-config-row.tsx
+++ b/client/components/column-config/column-config-row.tsx
@@ -15,7 +15,6 @@ interface ColumnConfigRowProps {
   columnTypes: { label: string; value: string }[];
   updateConfig: (updates: Partial<ColumnConfig>) => void;
   isEdit: boolean;
-  onFilterToggle?: () => void;
 }
 
 export const ColumnConfigRow: React.FC<ColumnConfigRowProps> = ({

--- a/client/components/column-config/column-config-row.tsx
+++ b/client/components/column-config/column-config-row.tsx
@@ -23,6 +23,7 @@ export const ColumnConfigRow: React.FC<ColumnConfigRowProps> = ({
   columnTypes,
   updateConfig,
   isEdit,
+  onFilterToggle,
 }) => {
   return (
     <ResponsiveFormRow>

--- a/client/components/column-config/column-config-row.tsx
+++ b/client/components/column-config/column-config-row.tsx
@@ -63,10 +63,6 @@ export const ColumnConfigRow: React.FC<ColumnConfigRowProps> = ({
               updateConfig({ filterable: checked, filterValues: [] })
             } else {
               updateConfig({ filterable: checked })
-              onFilterToggle?.()
-            }
-            if (!checked) {
-              updateConfig({ filterable: checked })
             }
           }}
           label="Filterable"

--- a/client/components/column-config/column-config-row.tsx
+++ b/client/components/column-config/column-config-row.tsx
@@ -15,6 +15,7 @@ interface ColumnConfigRowProps {
   columnTypes: { label: string; value: string }[];
   updateConfig: (updates: Partial<ColumnConfig>) => void;
   isEdit: boolean;
+  onFilterToggle?: () => void;
 }
 
 export const ColumnConfigRow: React.FC<ColumnConfigRowProps> = ({

--- a/client/components/column-config/column-config-row.tsx
+++ b/client/components/column-config/column-config-row.tsx
@@ -28,9 +28,9 @@ export const ColumnConfigRow: React.FC<ColumnConfigRowProps> = ({
   return (
     <ResponsiveFormRow>
       <ResponsiveFormGroup>
-        <FormLabel htmlFor='column-name'>Column Name</FormLabel>
+        <FormLabel htmlFor={`column-name-${columnId}`}>Column Name</FormLabel>
         <FormInput
-          id='column-name'
+          id={`column-name-${columnId}`}
           type='text'
           value={(config?.label || '')}
           onChange={(e) => updateConfig({ label: e.target.value })}
@@ -39,9 +39,9 @@ export const ColumnConfigRow: React.FC<ColumnConfigRowProps> = ({
       </ResponsiveFormGroup>
 
       <ResponsiveFormGroup>
-        <FormLabel htmlFor='column-type'>Column Type</FormLabel>
+        <FormLabel htmlFor={`column-type-${columnId}`}>Column Type</FormLabel>
         <FormSelect
-          id='column-type'
+          id={`column-type-${columnId}`}
           value={(config?.columnType || '')}
           onChange={(e) =>
             updateConfig({ columnType: e.target.value as ColumnConfig['columnType'] })
@@ -58,7 +58,7 @@ export const ColumnConfigRow: React.FC<ColumnConfigRowProps> = ({
 
       <ResponsiveFormGroupToggle>
         <Toggle
-          id='is-filterable'
+          id={`is-filterable-${columnId}`}
           checked={(config?.filterable || false)}
           onChange={(checked) => {
             if (!checked) {
@@ -73,7 +73,7 @@ export const ColumnConfigRow: React.FC<ColumnConfigRowProps> = ({
 
       <ResponsiveFormGroupToggle>
         <Toggle
-          id='is-hidden'
+          id={`is-hidden-${columnId}`}
           checked={(config?.hidden || false)}
           onChange={(checked) => updateConfig({ hidden: checked })}
           label="Hidden"
@@ -82,7 +82,7 @@ export const ColumnConfigRow: React.FC<ColumnConfigRowProps> = ({
 
       <ResponsiveFormGroupToggle>
         <Toggle
-          id='is-searchable'
+          id={`is-searchable-${columnId}`}
           checked={(config?.searchable || false)}
           onChange={(checked) => updateConfig({ searchable: checked })}
           label="Searchable"

--- a/client/components/column-config/column-config-row.tsx
+++ b/client/components/column-config/column-config-row.tsx
@@ -22,7 +22,6 @@ export const ColumnConfigRow: React.FC<ColumnConfigRowProps> = ({
   columnTypes,
   updateConfig,
   isEdit,
-  onFilterToggle,
 }) => {
   return (
     <ResponsiveFormRow>

--- a/client/components/column-config/column-config-row.tsx
+++ b/client/components/column-config/column-config-row.tsx
@@ -15,6 +15,7 @@ interface ColumnConfigRowProps {
   columnTypes: { label: string; value: string }[];
   updateConfig: (updates: Partial<ColumnConfig>) => void;
   isEdit: boolean;
+  columnId: string;
 }
 
 export const ColumnConfigRow: React.FC<ColumnConfigRowProps> = ({

--- a/client/components/column-config/index.tsx
+++ b/client/components/column-config/index.tsx
@@ -40,7 +40,7 @@ export const ColumnConfigForm: React.FC<ColumnConfigFormProps> = ({
 
   const [filterInput, setFilterInput] = useState('');
 
-  // Sync with initialConfig changes (for new columns or external updates)
+  // Only sync initialConfig on mount to avoid overwriting user input
   useEffect(() => {
     setConfig({
       label: initialConfig?.label || '',
@@ -51,7 +51,7 @@ export const ColumnConfigForm: React.FC<ColumnConfigFormProps> = ({
       searchable: initialConfig?.searchable || false,
       filterValues: initialConfig?.filterValues || []
     });
-  }, [initialConfig]);
+  }, [columnId]); // Only re-sync when columnId changes (new column)
 
   const updateConfig = (updates: Partial<ColumnConfig>) => {
     const newConfig = { ...config, ...updates };

--- a/client/components/column-config/index.tsx
+++ b/client/components/column-config/index.tsx
@@ -18,8 +18,6 @@ interface ColumnConfigFormProps {
   initialConfig?: Partial<ColumnConfig>;
   isEdit?: boolean;
   columnTypes?: LabelValue[];
-  isFilterExpanded?: boolean;
-  onFilterToggle?: () => void;
 }
 
 export const ColumnConfigForm: React.FC<ColumnConfigFormProps> = ({

--- a/client/components/column-config/index.tsx
+++ b/client/components/column-config/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState, KeyboardEvent, useEffect } from 'react';
+import React, { useState, KeyboardEvent, useEffect } from "react";
 import {
   ResponsiveColumnConfigFormContainer,
   ResponsiveFilterTags,
@@ -7,11 +7,11 @@ import {
   FormInput,
   FilterSection,
   FilterInputGroup,
-  TagRemove
-} from './style';
-import { ColumnConfig, LabelValue } from './types';
-import { ColumnConfigRow } from './column-config-row';
-import { ShimmerRow } from './shimmer';
+  TagRemove,
+} from "./style";
+import { ColumnConfig, LabelValue } from "./types";
+import { ColumnConfigRow } from "./column-config-row";
+import { ShimmerRow } from "./shimmer";
 
 interface ColumnConfigFormProps {
   onConfigChange?: (config: ColumnConfig) => void;
@@ -26,30 +26,30 @@ export const ColumnConfigForm: React.FC<ColumnConfigFormProps> = ({
   initialConfig = {},
   isEdit = false,
   columnTypes = [],
-  columnId
+  columnId,
 }) => {
   const [config, setConfig] = useState<ColumnConfig>({
-    label: initialConfig?.label || '',
-    columnName: initialConfig?.columnName || '',
-    columnType: initialConfig?.columnType || 'string',
+    label: initialConfig?.label || "",
+    columnName: initialConfig?.columnName || "",
+    columnType: initialConfig?.columnType || "string",
     filterable: initialConfig?.filterable || false,
     hidden: initialConfig?.hidden || false,
     searchable: initialConfig?.searchable || false,
-    filterValues: initialConfig?.filterValues || []
+    filterValues: initialConfig?.filterValues || [],
   });
 
-  const [filterInput, setFilterInput] = useState('');
+  const [filterInput, setFilterInput] = useState("");
 
   // Only sync initialConfig on mount to avoid overwriting user input
   useEffect(() => {
     setConfig({
-      label: initialConfig?.label || '',
-      columnName: initialConfig?.columnName || '',
-      columnType: initialConfig?.columnType || 'STRING',
+      label: initialConfig?.label || "",
+      columnName: initialConfig?.columnName || "",
+      columnType: initialConfig?.columnType || "STRING",
       filterable: initialConfig?.filterable || false,
       hidden: initialConfig?.hidden || false,
       searchable: initialConfig?.searchable || false,
-      filterValues: initialConfig?.filterValues || []
+      filterValues: initialConfig?.filterValues || [],
     });
   }, [columnId]); // Only re-sync when columnId changes (new column)
 
@@ -60,19 +60,21 @@ export const ColumnConfigForm: React.FC<ColumnConfigFormProps> = ({
   };
 
   const handleFilterKeyPress = (e: KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === 'Enter' && filterInput.trim()) {
+    if (e.key === "Enter" && filterInput.trim()) {
       if (!(config?.filterValues || []).includes(filterInput.trim())) {
         updateConfig({
-          filterValues: [...(config?.filterValues || []), filterInput.trim()]
+          filterValues: [...(config?.filterValues || []), filterInput.trim()],
         });
       }
-      setFilterInput('');
+      setFilterInput("");
     }
   };
 
   const removeFilterValue = (valueToRemove: string) => {
     updateConfig({
-      filterValues: (config?.filterValues || []).filter(value => value !== valueToRemove)
+      filterValues: (config?.filterValues || []).filter(
+        (value) => value !== valueToRemove,
+      ),
     });
   };
 
@@ -83,22 +85,26 @@ export const ColumnConfigForm: React.FC<ColumnConfigFormProps> = ({
           config={config}
           columnTypes={columnTypes}
           updateConfig={updateConfig}
-          isEdit={((config?.columnName !== '') && isEdit)}
+          isEdit={config?.columnName !== "" && isEdit}
           columnId={columnId}
         />
-      ) : <ShimmerRow /> }
+      ) : (
+        <ShimmerRow />
+      )}
 
       {(config?.filterable || false) && (
         <FilterSection>
           <FilterInputGroup>
-            <FormLabel htmlFor={`filter-input-${columnId}`}>Filter Values</FormLabel>
+            <FormLabel htmlFor={`filter-input-${columnId}`}>
+              Filter Values
+            </FormLabel>
             <FormInput
               id={`filter-input-${columnId}`}
-              type='text'
+              type="text"
               value={filterInput}
               onChange={(e) => setFilterInput(e.target.value)}
               onKeyDown={handleFilterKeyPress}
-              style={{width: '33ch'}}
+              style={{ width: "33ch" }}
               placeholder="Type a value and press Enter to add"
             />
           </FilterInputGroup>
@@ -109,7 +115,7 @@ export const ColumnConfigForm: React.FC<ColumnConfigFormProps> = ({
                 <ResponsiveFilterTag key={index}>
                   {value}
                   <TagRemove
-                    type='button'
+                    type="button"
                     onClick={() => removeFilterValue(value)}
                     aria-label={`Remove ${value}`}
                   >

--- a/client/components/column-config/index.tsx
+++ b/client/components/column-config/index.tsx
@@ -73,6 +73,7 @@ export const ColumnConfigForm: React.FC<ColumnConfigFormProps> = ({
           columnTypes={columnTypes}
           updateConfig={updateConfig}
           isEdit={((config?.columnName !== '') && isEdit)}
+          onFilterToggle={onFilterToggle}
         />
       ) : <ShimmerRow /> }
 

--- a/client/components/column-config/index.tsx
+++ b/client/components/column-config/index.tsx
@@ -69,7 +69,6 @@ export const ColumnConfigForm: React.FC<ColumnConfigFormProps> = ({
           columnTypes={columnTypes}
           updateConfig={updateConfig}
           isEdit={((config?.columnName !== '') && isEdit)}
-          onFilterToggle={onFilterToggle}
         />
       ) : <ShimmerRow /> }
 

--- a/client/components/column-config/index.tsx
+++ b/client/components/column-config/index.tsx
@@ -24,9 +24,7 @@ export const ColumnConfigForm: React.FC<ColumnConfigFormProps> = ({
   onConfigChange,
   initialConfig = {},
   isEdit = false,
-  columnTypes = [],
-  isFilterExpanded = false,
-  onFilterToggle
+  columnTypes = []
 }) => {
   const [config, setConfig] = useState<ColumnConfig>({
     label: initialConfig?.label || '',

--- a/client/components/column-config/index.tsx
+++ b/client/components/column-config/index.tsx
@@ -71,15 +71,16 @@ export const ColumnConfigForm: React.FC<ColumnConfigFormProps> = ({
           columnTypes={columnTypes}
           updateConfig={updateConfig}
           isEdit={((config?.columnName !== '') && isEdit)}
+          columnId={columnId}
         />
       ) : <ShimmerRow /> }
 
       {(config?.filterable || false) && (
         <FilterSection>
           <FilterInputGroup>
-            <FormLabel htmlFor='filter-input'>Filter Values</FormLabel>
+            <FormLabel htmlFor={`filter-input-${columnId}`}>Filter Values</FormLabel>
             <FormInput
-              id='filter-input'
+              id={`filter-input-${columnId}`}
               type='text'
               value={filterInput}
               onChange={(e) => setFilterInput(e.target.value)}

--- a/client/components/column-config/index.tsx
+++ b/client/components/column-config/index.tsx
@@ -77,7 +77,7 @@ export const ColumnConfigForm: React.FC<ColumnConfigFormProps> = ({
         />
       ) : <ShimmerRow /> }
 
-      {(config?.filterable || false) && isFilterExpanded && (
+      {(config?.filterable || false) && (
         <FilterSection>
           <FilterInputGroup>
             <FormLabel htmlFor='filter-input'>Filter Values</FormLabel>

--- a/client/components/column-config/index.tsx
+++ b/client/components/column-config/index.tsx
@@ -18,6 +18,7 @@ interface ColumnConfigFormProps {
   initialConfig?: Partial<ColumnConfig>;
   isEdit?: boolean;
   columnTypes?: LabelValue[];
+  columnId: string;
 }
 
 export const ColumnConfigForm: React.FC<ColumnConfigFormProps> = ({

--- a/client/components/column-config/index.tsx
+++ b/client/components/column-config/index.tsx
@@ -25,7 +25,8 @@ export const ColumnConfigForm: React.FC<ColumnConfigFormProps> = ({
   onConfigChange,
   initialConfig = {},
   isEdit = false,
-  columnTypes = []
+  columnTypes = [],
+  columnId
 }) => {
   const [config, setConfig] = useState<ColumnConfig>({
     label: initialConfig?.label || '',

--- a/client/components/column-config/index.tsx
+++ b/client/components/column-config/index.tsx
@@ -18,13 +18,17 @@ interface ColumnConfigFormProps {
   initialConfig?: Partial<ColumnConfig>;
   isEdit?: boolean;
   columnTypes?: LabelValue[];
+  isFilterExpanded?: boolean;
+  onFilterToggle?: () => void;
 }
 
 export const ColumnConfigForm: React.FC<ColumnConfigFormProps> = ({
   onConfigChange,
   initialConfig = {},
   isEdit = false,
-  columnTypes = []
+  columnTypes = [],
+  isFilterExpanded = false,
+  onFilterToggle
 }) => {
   const [config, setConfig] = useState<ColumnConfig>({
     label: initialConfig?.label || '',
@@ -72,7 +76,7 @@ export const ColumnConfigForm: React.FC<ColumnConfigFormProps> = ({
         />
       ) : <ShimmerRow /> }
 
-      {(config?.filterable || false) && (
+      {(config?.filterable || false) && isFilterExpanded && (
         <FilterSection>
           <FilterInputGroup>
             <FormLabel htmlFor='filter-input'>Filter Values</FormLabel>

--- a/client/components/column-config/index.tsx
+++ b/client/components/column-config/index.tsx
@@ -40,6 +40,19 @@ export const ColumnConfigForm: React.FC<ColumnConfigFormProps> = ({
 
   const [filterInput, setFilterInput] = useState('');
 
+  // Sync with initialConfig changes (for new columns or external updates)
+  useEffect(() => {
+    setConfig({
+      label: initialConfig?.label || '',
+      columnName: initialConfig?.columnName || '',
+      columnType: initialConfig?.columnType || 'STRING',
+      filterable: initialConfig?.filterable || false,
+      hidden: initialConfig?.hidden || false,
+      searchable: initialConfig?.searchable || false,
+      filterValues: initialConfig?.filterValues || []
+    });
+  }, [initialConfig]);
+
   const updateConfig = (updates: Partial<ColumnConfig>) => {
     const newConfig = { ...config, ...updates };
     setConfig(newConfig);

--- a/client/components/registration/registration.tsx
+++ b/client/components/registration/registration.tsx
@@ -235,20 +235,6 @@ export default function RegistrationStepperModal() {
     columns.length > 0 &&
     columns.every((col) => col.label && col.label.trim() !== '' && col.columnType && col.columnType.trim() !== '');
 
-  // Debug logging
-  console.log('Current step:', currentStep);
-  console.log('Steps length:', steps.length);
-  console.log('Show Create Table button:', currentStep >= steps.length);
-  console.log('Columns state:', columns);
-  console.log('isStep2Valid:', isStep2Valid);
-  console.log('Column validation details:', columns.map(col => ({
-    id: col.id,
-    label: col.label,
-    labelValid: col.label && col.label.trim() !== '',
-    columnType: col.columnType,
-    typeValid: col.columnType && col.columnType.trim() !== ''
-  })));
-
   return (
     <Overlay>
       <ModalContainer>

--- a/client/components/registration/registration.tsx
+++ b/client/components/registration/registration.tsx
@@ -494,7 +494,7 @@ export default function RegistrationStepperModal() {
                       <div style={{
                         maxHeight: "400px",
                         overflowY: "auto",
-                        padding: "0 8px 8px 0",
+                        padding: "0 8px 0 0",
                         background: "linear-gradient(to bottom, #f8fafc 0%, #ffffff 100%)",
                         borderRadius: "8px",
                         border: "1px solid #f1f5f9"

--- a/client/components/registration/registration.tsx
+++ b/client/components/registration/registration.tsx
@@ -236,6 +236,9 @@ export default function RegistrationStepperModal() {
     columns.every((col) => col.label && col.label.trim() !== '' && col.columnType && col.columnType.trim() !== '');
 
   // Debug logging
+  console.log('Current step:', currentStep);
+  console.log('Steps length:', steps.length);
+  console.log('Show Create Table button:', currentStep >= steps.length);
   console.log('Columns state:', columns);
   console.log('isStep2Valid:', isStep2Valid);
   console.log('Column validation details:', columns.map(col => ({

--- a/client/components/registration/registration.tsx
+++ b/client/components/registration/registration.tsx
@@ -309,7 +309,7 @@ export default function RegistrationStepperModal() {
     <>
       <style dangerouslySetInnerHTML={{ __html: enhancedScrollStyle }} />
       <Overlay>
-      <ModalContainer>
+        <ModalContainer className="modal-container-fixed">
         {isCompleted ? (
           <CompletionContainer>
             <CompletionIcon>

--- a/client/components/registration/registration.tsx
+++ b/client/components/registration/registration.tsx
@@ -102,11 +102,18 @@ interface OrganizationData {
 }
 
 export default function RegistrationStepperModal() {
-  // Enhanced CSS for smooth scrolling with internal scrollbar only
+  // Enhanced CSS for synchronized scrolling - only internal scrollbar
   const enhancedScrollStyle = `
-    /* Hide external scrollbars */
+    /* Prevent external page scrolling */
     body {
-      overflow: hidden;
+      overflow: hidden !important;
+    }
+
+    /* Ensure modal container doesn't overflow */
+    .modal-container-fixed {
+      height: 90vh !important;
+      max-height: 90vh !important;
+      overflow: hidden !important;
     }
 
     /* Internal scrollbar styling */

--- a/client/components/registration/registration.tsx
+++ b/client/components/registration/registration.tsx
@@ -525,20 +525,47 @@ export default function RegistrationStepperModal() {
                                  boxShadow: "0 2px 8px -2px rgba(0, 0, 0, 0.08)",
                                  position: "relative"
                                }}>
-                            <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: "16px" }}>
-                              <h3 style={{ margin: 0, fontSize: "16px", fontWeight: "600", color: "#374151" }}>
+                            <div style={{
+                              display: "flex",
+                              justifyContent: "space-between",
+                              alignItems: "center",
+                              marginBottom: "20px",
+                              paddingBottom: "12px",
+                              borderBottom: "1px solid #f1f5f9"
+                            }}>
+                              <h3 style={{
+                                margin: 0,
+                                fontSize: "18px",
+                                fontWeight: "600",
+                                color: "#1e293b",
+                                background: "linear-gradient(135deg, #3b82f6, #8b5cf6)",
+                                WebkitBackgroundClip: "text",
+                                WebkitTextFillColor: "transparent"
+                              }}>
                                 Column {index + 1}
                               </h3>
                               {columns.length > 1 && (
                                 <button
                                   onClick={() => removeColumn(column.id)}
                                   style={{
-                                    background: "none",
-                                    border: "none",
-                                    color: "#ef4444",
+                                    background: "linear-gradient(135deg, #fee2e2, #fef2f2)",
+                                    border: "1px solid #fecaca",
+                                    color: "#dc2626",
                                     cursor: "pointer",
-                                    padding: "4px",
-                                    borderRadius: "4px"
+                                    padding: "8px",
+                                    borderRadius: "8px",
+                                    transition: "all 0.2s ease",
+                                    display: "flex",
+                                    alignItems: "center",
+                                    justifyContent: "center"
+                                  }}
+                                  onMouseEnter={(e) => {
+                                    e.currentTarget.style.background = "linear-gradient(135deg, #fecaca, #fee2e2)";
+                                    e.currentTarget.style.transform = "scale(1.05)";
+                                  }}
+                                  onMouseLeave={(e) => {
+                                    e.currentTarget.style.background = "linear-gradient(135deg, #fee2e2, #fef2f2)";
+                                    e.currentTarget.style.transform = "scale(1)";
                                   }}
                                 >
                                   <X size={16} />

--- a/client/components/registration/registration.tsx
+++ b/client/components/registration/registration.tsx
@@ -102,30 +102,16 @@ interface OrganizationData {
 }
 
 export default function RegistrationStepperModal() {
-  // Enhanced CSS for smooth scrolling and attractive design
+  // Enhanced CSS for smooth scrolling without visible scrollbar
   const enhancedScrollStyle = `
     .smooth-scroll-container {
       scroll-behavior: smooth;
-      scrollbar-width: thin;
-      scrollbar-color: #e5e7eb transparent;
+      scrollbar-width: none; /* Firefox */
+      -ms-overflow-style: none; /* IE and Edge */
     }
 
     .smooth-scroll-container::-webkit-scrollbar {
-      width: 4px;
-    }
-
-    .smooth-scroll-container::-webkit-scrollbar-track {
-      background: transparent;
-    }
-
-    .smooth-scroll-container::-webkit-scrollbar-thumb {
-      background: #e5e7eb;
-      border-radius: 2px;
-      transition: background 0.2s ease;
-    }
-
-    .smooth-scroll-container::-webkit-scrollbar-thumb:hover {
-      background: #d1d5db;
+      display: none; /* Chrome, Safari, Opera */
     }
 
     .column-card {

--- a/client/components/registration/registration.tsx
+++ b/client/components/registration/registration.tsx
@@ -69,13 +69,15 @@ interface LoginResp {
 }
 
 // Mock API function - replace with actual import
-const srGetRegistrationData = async (payload: RegistrationStepperModalRequest): Promise<LoginResp> => {
+const srGetRegistrationData = async (
+  payload: RegistrationStepperModalRequest,
+): Promise<LoginResp> => {
   // Simulate API call
   return new Promise((resolve) => {
     setTimeout(() => {
       resolve({
         respMessage: "Registration successful!",
-        businesses: [{ id: 1, name: payload.businessName }]
+        businesses: [{ id: 1, name: payload.businessName }],
       });
     }, 1000);
   });
@@ -83,8 +85,10 @@ const srGetRegistrationData = async (payload: RegistrationStepperModalRequest): 
 
 // Mock business store functions - replace with actual store imports
 const useBusinessStore = () => ({
-  setSelectedBusiness: (business: any) => console.log("Selected business:", business),
-  setBusinesses: (businesses: any[]) => console.log("Set businesses:", businesses),
+  setSelectedBusiness: (business: any) =>
+    console.log("Selected business:", business),
+  setBusinesses: (businesses: any[]) =>
+    console.log("Set businesses:", businesses),
 });
 
 // Mock router - replace with actual router import
@@ -92,7 +96,7 @@ const useRouter = () => ({
   push: (path: string) => {
     console.log("Navigate to:", path);
     // In a real app, this would navigate to the home page
-  }
+  },
 });
 
 interface OrganizationData {
@@ -199,7 +203,6 @@ export default function RegistrationStepperModal() {
     },
   ]);
 
-
   const steps = [
     {
       id: 1,
@@ -224,7 +227,7 @@ export default function RegistrationStepperModal() {
 
   const updateOrganizationData = (
     field: keyof OrganizationData,
-    value: string
+    value: string,
   ) => {
     setOrganizationData((prev) => ({ ...prev, [field]: value }));
   };
@@ -245,7 +248,7 @@ export default function RegistrationStepperModal() {
 
   const updateColumn = (id: string, updates: Partial<ColumnConfig>) => {
     setColumns(
-      columns.map((col) => (col.id === id ? { ...col, ...updates } : col))
+      columns.map((col) => (col.id === id ? { ...col, ...updates } : col)),
     );
   };
 
@@ -290,7 +293,7 @@ export default function RegistrationStepperModal() {
         setBusinesses(resp?.businesses);
 
         setTimeout(() => {
-          router.push('/home');
+          router.push("/home");
         }, 1000);
       })
       .catch((err: any) => toast.error(err.errorMsg));
@@ -303,343 +306,370 @@ export default function RegistrationStepperModal() {
 
   const isStep2Valid =
     columns.length > 0 &&
-    columns.every((col) => col.label && col.label.trim() !== '' && col.columnType && col.columnType.trim() !== '');
+    columns.every(
+      (col) =>
+        col.label &&
+        col.label.trim() !== "" &&
+        col.columnType &&
+        col.columnType.trim() !== "",
+    );
 
   return (
     <>
       <style dangerouslySetInnerHTML={{ __html: enhancedScrollStyle }} />
       <Overlay>
         <ModalContainer className="modal-container-fixed">
-        {isCompleted ? (
-          <CompletionContainer>
-            <CompletionIcon>
-              <CheckCircle size={32} color="#16a34a" />
-            </CompletionIcon>
-            <CompletionTitle>Table Created!</CompletionTitle>
-            <CompletionText>
-              Your table configuration has been saved successfully.
-            </CompletionText>
-          </CompletionContainer>
-        ) : (
-          <>
-            {/* Header */}
-            <ModalHeader>
-              <ModalHeaderContent>
-                <ModalTitle>{steps[currentStep - 1].title}</ModalTitle>
-                <ModalSubtitle>
-                  {steps[currentStep - 1].description}
-                </ModalSubtitle>
-              </ModalHeaderContent>
-              <ModalBadge>
-                Step {currentStep} of {steps.length}
-              </ModalBadge>
-            </ModalHeader>
+          {isCompleted ? (
+            <CompletionContainer>
+              <CompletionIcon>
+                <CheckCircle size={32} color="#16a34a" />
+              </CompletionIcon>
+              <CompletionTitle>Table Created!</CompletionTitle>
+              <CompletionText>
+                Your table configuration has been saved successfully.
+              </CompletionText>
+            </CompletionContainer>
+          ) : (
+            <>
+              {/* Header */}
+              <ModalHeader>
+                <ModalHeaderContent>
+                  <ModalTitle>{steps[currentStep - 1].title}</ModalTitle>
+                  <ModalSubtitle>
+                    {steps[currentStep - 1].description}
+                  </ModalSubtitle>
+                </ModalHeaderContent>
+                <ModalBadge>
+                  Step {currentStep} of {steps.length}
+                </ModalBadge>
+              </ModalHeader>
 
-            {/* Progress Bar */}
-            <ProgressBar>
-              <ProgressContainer>
-                {steps.map((step, index) => {
-                  const isActive = step.id === currentStep;
-                  const isCompleted = step.id < currentStep;
-                  const StepIcon = step.icon;
+              {/* Progress Bar */}
+              <ProgressBar>
+                <ProgressContainer>
+                  {steps.map((step, index) => {
+                    const isActive = step.id === currentStep;
+                    const isCompleted = step.id < currentStep;
+                    const StepIcon = step.icon;
 
-                  return (
-                    <React.Fragment key={step.id}>
-                      <StepContainer>
-                        <StepCircle
-                          isActive={isActive}
-                          isCompleted={isCompleted}
-                        >
-                          {isCompleted ? (
-                            <Check size={20} />
-                          ) : (
-                            <StepIcon size={20} />
-                          )}
-                        </StepCircle>
-                        <StepInfo>
-                          <StepTitle
+                    return (
+                      <React.Fragment key={step.id}>
+                        <StepContainer>
+                          <StepCircle
                             isActive={isActive}
                             isCompleted={isCompleted}
                           >
-                            {step.title}
-                          </StepTitle>
-                          <StepDescription>{step.description}</StepDescription>
-                        </StepInfo>
-                      </StepContainer>
+                            {isCompleted ? (
+                              <Check size={20} />
+                            ) : (
+                              <StepIcon size={20} />
+                            )}
+                          </StepCircle>
+                          <StepInfo>
+                            <StepTitle
+                              isActive={isActive}
+                              isCompleted={isCompleted}
+                            >
+                              {step.title}
+                            </StepTitle>
+                            <StepDescription>
+                              {step.description}
+                            </StepDescription>
+                          </StepInfo>
+                        </StepContainer>
 
-                      {index < steps.length - 1 && (
-                        <ProgressLine isCompleted={currentStep > step.id} />
-                      )}
-                    </React.Fragment>
-                  );
-                })}
-              </ProgressContainer>
-            </ProgressBar>
+                        {index < steps.length - 1 && (
+                          <ProgressLine isCompleted={currentStep > step.id} />
+                        )}
+                      </React.Fragment>
+                    );
+                  })}
+                </ProgressContainer>
+              </ProgressBar>
 
-            {/* Content */}
-            <Content>
-              <AnimatePresence mode="wait" custom={direction}>
-                {currentStep === 1 && (
-                  <motion.div
-                    key="step1"
-                    custom={direction}
-                    initial="enter"
-                    animate="center"
-                    exit="exit"
-                    variants={{
-                      enter: (direction: number) => ({
-                        x: direction > 0 ? 300 : -300,
-                        opacity: 0,
-                      }),
-                      center: {
-                        zIndex: 1,
-                        x: 0,
-                        opacity: 1,
-                      },
-                      exit: (direction: number) => ({
-                        zIndex: 0,
-                        x: direction < 0 ? 300 : -300,
-                        opacity: 0,
-                      }),
-                    }}
-                    transition={{
-                      x: { type: "spring", stiffness: 300, damping: 30 },
-                      opacity: { duration: 0.2 },
-                    }}
-                  >
-                    <FormContainer>
-                      <FormGroup>
-                        <Label htmlFor="organizationName">
-                          Organization Name *
-                        </Label>
-                        <Input
-                          id="organizationName"
-                          value={organizationData.organizationName}
-                          onChange={(e) =>
-                            updateOrganizationData(
-                              "organizationName",
-                              e.target.value
-                            )
-                          }
-                          placeholder="Enter your organization name"
-                        />
-                      </FormGroup>
-
-                      <FormGroup>
-                        <Label htmlFor="organizationId">
-                          Organization ID *
-                        </Label>
-                        <Input
-                          id="organizationId"
-                          value={organizationData.organizationId}
-                          onChange={(e) =>
-                            updateOrganizationData(
-                              "organizationId",
-                              e.target.value
-                            )
-                          }
-                          placeholder="Enter organization ID (e.g., org_12345)"
-                        />
-                        <HelpText>
-                          This will be used as a unique identifier for your
-                          organization
-                        </HelpText>
-                      </FormGroup>
-
-                      <FormGroup>
-                        <Label htmlFor="tablePrefix">Table Prefix *</Label>
-                        <Input
-                          id="tablePrefix"
-                          value={organizationData.tablePrefix}
-                          onChange={(e) =>
-                            updateOrganizationData(
-                              "tablePrefix",
-                              e.target.value
-                            )
-                          }
-                          placeholder="Enter table prefix (e.g., usr_)"
-                        />
-                        <HelpText>
-                          This prefix will be added to all table names for
-                          organization
-                        </HelpText>
-                      </FormGroup>
-                    </FormContainer>
-                  </motion.div>
-                )}
-
-                {currentStep === 2 && (
-                  <motion.div
-                    key="step2"
-                    custom={direction}
-                    initial="enter"
-                    animate="center"
-                    exit="exit"
-                    variants={{
-                      enter: (direction: number) => ({
-                        x: direction > 0 ? 300 : -300,
-                        opacity: 0,
-                      }),
-                      center: {
-                        zIndex: 1,
-                        x: 0,
-                        opacity: 1,
-                      },
-                      exit: (direction: number) => ({
-                        zIndex: 0,
-                        x: direction < 0 ? 300 : -300,
-                        opacity: 0,
-                      }),
-                    }}
-                    transition={{
-                      x: { type: "spring", stiffness: 300, damping: 30 },
-                      opacity: { duration: 0.2 },
-                    }}
-                  >
-                    <div style={{ position: "relative" }}>
-                      {/* Fixed Add Column Button - Outside scrollable area */}
-                      <div style={{
-                        display: "flex",
-                        justifyContent: "flex-end",
-                        padding: "0 0 12px 0",
-                        marginBottom: "8px",
-                        borderBottom: "1px solid #e2e8f0"
-                      }}>
-                        <Button variant="secondary" onClick={addColumn}>
-                          <Plus size={16} />
-                          Add Column
-                        </Button>
-                      </div>
-
-                      {/* Enhanced Scrollable Columns Container */}
-                      <div style={{
-                        maxHeight: "400px",
-                        overflowY: "auto",
-                        padding: "16px 8px 0 0",
-                        background: "linear-gradient(to bottom, #f8fafc 0%, #ffffff 100%)",
-                        borderRadius: "8px",
-                        border: "1px solid #f1f5f9"
+              {/* Content */}
+              <Content>
+                <AnimatePresence mode="wait" custom={direction}>
+                  {currentStep === 1 && (
+                    <motion.div
+                      key="step1"
+                      custom={direction}
+                      initial="enter"
+                      animate="center"
+                      exit="exit"
+                      variants={{
+                        enter: (direction: number) => ({
+                          x: direction > 0 ? 300 : -300,
+                          opacity: 0,
+                        }),
+                        center: {
+                          zIndex: 1,
+                          x: 0,
+                          opacity: 1,
+                        },
+                        exit: (direction: number) => ({
+                          zIndex: 0,
+                          x: direction < 0 ? 300 : -300,
+                          opacity: 0,
+                        }),
                       }}
-                      className="smooth-scroll-container"
-                      >
-                        {columns.map((column, index) => (
-                          <div key={column.id}
-                               className="column-card animate-fade-in"
-                               style={{
-                                 marginBottom: index === columns.length - 1 ? "0px" : "20px",
-                                 padding: "24px",
-                                 border: "1px solid #e2e8f0",
-                                 borderRadius: "16px",
-                                 backgroundColor: "#ffffff",
-                                 boxShadow: "0 2px 8px -2px rgba(0, 0, 0, 0.08)",
-                                 position: "relative"
-                               }}>
-                            <div style={{
-                              display: "flex",
-                              justifyContent: "space-between",
-                              alignItems: "center",
-                              marginBottom: "20px",
-                              paddingBottom: "12px",
-                              borderBottom: "1px solid #f1f5f9"
-                            }}>
-                              <h3 style={{
-                                margin: 0,
-                                fontSize: "18px",
-                                fontWeight: "600",
-                                color: "#1e293b",
-                                background: "linear-gradient(135deg, #3b82f6, #8b5cf6)",
-                                WebkitBackgroundClip: "text",
-                                WebkitTextFillColor: "transparent"
-                              }}>
-                                Column {index + 1}
-                              </h3>
-                              {columns.length > 1 && (
-                                <button
-                                  onClick={() => removeColumn(column.id)}
+                      transition={{
+                        x: { type: "spring", stiffness: 300, damping: 30 },
+                        opacity: { duration: 0.2 },
+                      }}
+                    >
+                      <FormContainer>
+                        <FormGroup>
+                          <Label htmlFor="organizationName">
+                            Organization Name *
+                          </Label>
+                          <Input
+                            id="organizationName"
+                            value={organizationData.organizationName}
+                            onChange={(e) =>
+                              updateOrganizationData(
+                                "organizationName",
+                                e.target.value,
+                              )
+                            }
+                            placeholder="Enter your organization name"
+                          />
+                        </FormGroup>
+
+                        <FormGroup>
+                          <Label htmlFor="organizationId">
+                            Organization ID *
+                          </Label>
+                          <Input
+                            id="organizationId"
+                            value={organizationData.organizationId}
+                            onChange={(e) =>
+                              updateOrganizationData(
+                                "organizationId",
+                                e.target.value,
+                              )
+                            }
+                            placeholder="Enter organization ID (e.g., org_12345)"
+                          />
+                          <HelpText>
+                            This will be used as a unique identifier for your
+                            organization
+                          </HelpText>
+                        </FormGroup>
+
+                        <FormGroup>
+                          <Label htmlFor="tablePrefix">Table Prefix *</Label>
+                          <Input
+                            id="tablePrefix"
+                            value={organizationData.tablePrefix}
+                            onChange={(e) =>
+                              updateOrganizationData(
+                                "tablePrefix",
+                                e.target.value,
+                              )
+                            }
+                            placeholder="Enter table prefix (e.g., usr_)"
+                          />
+                          <HelpText>
+                            This prefix will be added to all table names for
+                            organization
+                          </HelpText>
+                        </FormGroup>
+                      </FormContainer>
+                    </motion.div>
+                  )}
+
+                  {currentStep === 2 && (
+                    <motion.div
+                      key="step2"
+                      custom={direction}
+                      initial="enter"
+                      animate="center"
+                      exit="exit"
+                      variants={{
+                        enter: (direction: number) => ({
+                          x: direction > 0 ? 300 : -300,
+                          opacity: 0,
+                        }),
+                        center: {
+                          zIndex: 1,
+                          x: 0,
+                          opacity: 1,
+                        },
+                        exit: (direction: number) => ({
+                          zIndex: 0,
+                          x: direction < 0 ? 300 : -300,
+                          opacity: 0,
+                        }),
+                      }}
+                      transition={{
+                        x: { type: "spring", stiffness: 300, damping: 30 },
+                        opacity: { duration: 0.2 },
+                      }}
+                    >
+                      <div style={{ position: "relative" }}>
+                        {/* Fixed Add Column Button - Outside scrollable area */}
+                        <div
+                          style={{
+                            display: "flex",
+                            justifyContent: "flex-end",
+                            padding: "0 0 12px 0",
+                            marginBottom: "8px",
+                            borderBottom: "1px solid #e2e8f0",
+                          }}
+                        >
+                          <Button variant="secondary" onClick={addColumn}>
+                            <Plus size={16} />
+                            Add Column
+                          </Button>
+                        </div>
+
+                        {/* Enhanced Scrollable Columns Container */}
+                        <div
+                          style={{
+                            maxHeight: "400px",
+                            overflowY: "auto",
+                            padding: "16px 8px 0 0",
+                            background:
+                              "linear-gradient(to bottom, #f8fafc 0%, #ffffff 100%)",
+                            borderRadius: "8px",
+                            border: "1px solid #f1f5f9",
+                          }}
+                          className="smooth-scroll-container"
+                        >
+                          {columns.map((column, index) => (
+                            <div
+                              key={column.id}
+                              className="column-card animate-fade-in"
+                              style={{
+                                marginBottom:
+                                  index === columns.length - 1 ? "0px" : "20px",
+                                padding: "24px",
+                                border: "1px solid #e2e8f0",
+                                borderRadius: "16px",
+                                backgroundColor: "#ffffff",
+                                boxShadow: "0 2px 8px -2px rgba(0, 0, 0, 0.08)",
+                                position: "relative",
+                              }}
+                            >
+                              <div
+                                style={{
+                                  display: "flex",
+                                  justifyContent: "space-between",
+                                  alignItems: "center",
+                                  marginBottom: "20px",
+                                  paddingBottom: "12px",
+                                  borderBottom: "1px solid #f1f5f9",
+                                }}
+                              >
+                                <h3
                                   style={{
-                                    background: "linear-gradient(135deg, #fee2e2, #fef2f2)",
-                                    border: "1px solid #fecaca",
-                                    color: "#dc2626",
-                                    cursor: "pointer",
-                                    padding: "8px",
-                                    borderRadius: "8px",
-                                    transition: "all 0.2s ease",
-                                    display: "flex",
-                                    alignItems: "center",
-                                    justifyContent: "center"
-                                  }}
-                                  onMouseEnter={(e) => {
-                                    e.currentTarget.style.background = "linear-gradient(135deg, #fecaca, #fee2e2)";
-                                    e.currentTarget.style.transform = "scale(1.05)";
-                                  }}
-                                  onMouseLeave={(e) => {
-                                    e.currentTarget.style.background = "linear-gradient(135deg, #fee2e2, #fef2f2)";
-                                    e.currentTarget.style.transform = "scale(1)";
+                                    margin: 0,
+                                    fontSize: "18px",
+                                    fontWeight: "600",
+                                    color: "#1e293b",
+                                    background:
+                                      "linear-gradient(135deg, #3b82f6, #8b5cf6)",
+                                    WebkitBackgroundClip: "text",
+                                    WebkitTextFillColor: "transparent",
                                   }}
                                 >
-                                  <X size={16} />
-                                </button>
-                              )}
+                                  Column {index + 1}
+                                </h3>
+                                {columns.length > 1 && (
+                                  <button
+                                    onClick={() => removeColumn(column.id)}
+                                    style={{
+                                      background:
+                                        "linear-gradient(135deg, #fee2e2, #fef2f2)",
+                                      border: "1px solid #fecaca",
+                                      color: "#dc2626",
+                                      cursor: "pointer",
+                                      padding: "8px",
+                                      borderRadius: "8px",
+                                      transition: "all 0.2s ease",
+                                      display: "flex",
+                                      alignItems: "center",
+                                      justifyContent: "center",
+                                    }}
+                                    onMouseEnter={(e) => {
+                                      e.currentTarget.style.background =
+                                        "linear-gradient(135deg, #fecaca, #fee2e2)";
+                                      e.currentTarget.style.transform =
+                                        "scale(1.05)";
+                                    }}
+                                    onMouseLeave={(e) => {
+                                      e.currentTarget.style.background =
+                                        "linear-gradient(135deg, #fee2e2, #fef2f2)";
+                                      e.currentTarget.style.transform =
+                                        "scale(1)";
+                                    }}
+                                  >
+                                    <X size={16} />
+                                  </button>
+                                )}
+                              </div>
+                              <ColumnConfigForm
+                                initialConfig={{
+                                  label: column.label,
+                                  columnName: column.columnName,
+                                  columnType: column.columnType,
+                                  filterable: column.filterable,
+                                  hidden: column.hidden,
+                                  searchable: column.searchable,
+                                  filterValues: column.filterValues,
+                                }}
+                                columnTypes={columnTypes}
+                                onConfigChange={(config) =>
+                                  updateColumn(column.id, config)
+                                }
+                                isEdit={false}
+                                columnId={column.id}
+                              />
                             </div>
-                            <ColumnConfigForm
-                              initialConfig={{
-                                label: column.label,
-                                columnName: column.columnName,
-                                columnType: column.columnType,
-                                filterable: column.filterable,
-                                hidden: column.hidden,
-                                searchable: column.searchable,
-                                filterValues: column.filterValues,
-                              }}
-                              columnTypes={columnTypes}
-                              onConfigChange={(config) => updateColumn(column.id, config)}
-                              isEdit={false}
-                              columnId={column.id}
-                            />
-                          </div>
-                        ))}
+                          ))}
+                        </div>
                       </div>
-                    </div>
-                  </motion.div>
+                    </motion.div>
+                  )}
+                </AnimatePresence>
+              </Content>
+
+              {/* Footer */}
+              <Footer>
+                <Button
+                  variant="ghost"
+                  onClick={handleBack}
+                  disabled={currentStep === 1}
+                >
+                  <ArrowLeft size={16} />
+                  Back
+                </Button>
+
+                {currentStep < steps.length ? (
+                  <Button
+                    variant="primary"
+                    onClick={handleNext}
+                    disabled={currentStep === 1 ? !isStep1Valid : !isStep2Valid}
+                  >
+                    Next
+                    <ArrowRight size={16} />
+                  </Button>
+                ) : (
+                  <Button
+                    variant="primary"
+                    onClick={triggerRegistrationStepperModal}
+                    disabled={!isStep2Valid}
+                  >
+                    Create Table
+                    <Check size={16} />
+                  </Button>
                 )}
-              </AnimatePresence>
-            </Content>
-
-            {/* Footer */}
-            <Footer>
-              <Button
-                variant="ghost"
-                onClick={handleBack}
-                disabled={currentStep === 1}
-              >
-                <ArrowLeft size={16} />
-                Back
-              </Button>
-
-              {currentStep < steps.length ? (
-                <Button
-                  variant="primary"
-                  onClick={handleNext}
-                  disabled={currentStep === 1 ? !isStep1Valid : !isStep2Valid}
-                >
-                  Next
-                  <ArrowRight size={16} />
-                </Button>
-              ) : (
-                <Button
-                  variant="primary"
-                  onClick={triggerRegistrationStepperModal}
-                  disabled={!isStep2Valid}
-                >
-                  Create Table
-                  <Check size={16} />
-                </Button>
-              )}
-            </Footer>
-          </>
-        )}
-      </ModalContainer>
-    </Overlay>
+              </Footer>
+            </>
+          )}
+        </ModalContainer>
+      </Overlay>
     </>
   );
 }

--- a/client/components/registration/registration.tsx
+++ b/client/components/registration/registration.tsx
@@ -102,6 +102,13 @@ interface OrganizationData {
 }
 
 export default function RegistrationStepperModal() {
+  // CSS to hide scrollbar
+  const hideScrollbarStyle = `
+    .hide-scrollbar::-webkit-scrollbar {
+      display: none;
+    }
+  `;
+
   const router = useRouter();
   const { setSelectedBusiness, setBusinesses } = useBusinessStore();
 

--- a/client/components/registration/registration.tsx
+++ b/client/components/registration/registration.tsx
@@ -523,7 +523,7 @@ export default function RegistrationStepperModal() {
                           <div key={column.id}
                                className="column-card animate-fade-in"
                                style={{
-                                 marginBottom: "20px",
+                                 marginBottom: index === columns.length - 1 ? "0px" : "20px",
                                  padding: "24px",
                                  border: "1px solid #e2e8f0",
                                  borderRadius: "16px",

--- a/client/components/registration/registration.tsx
+++ b/client/components/registration/registration.tsx
@@ -173,6 +173,7 @@ export default function RegistrationStepperModal() {
   };
 
   const updateColumn = (id: string, updates: Partial<ColumnConfig>) => {
+    console.log('updateColumn called:', { id, updates });
     setColumns(
       columns.map((col) => (col.id === id ? { ...col, ...updates } : col))
     );

--- a/client/components/registration/registration.tsx
+++ b/client/components/registration/registration.tsx
@@ -242,7 +242,9 @@ export default function RegistrationStepperModal() {
     columns.every((col) => col.label && col.label.trim() !== '' && col.columnType && col.columnType.trim() !== '');
 
   return (
-    <Overlay>
+    <>
+      <style dangerouslySetInnerHTML={{ __html: hideScrollbarStyle }} />
+      <Overlay>
       <ModalContainer>
         {isCompleted ? (
           <CompletionContainer>
@@ -540,5 +542,6 @@ export default function RegistrationStepperModal() {
         )}
       </ModalContainer>
     </Overlay>
+    </>
   );
 }

--- a/client/components/registration/registration.tsx
+++ b/client/components/registration/registration.tsx
@@ -425,7 +425,15 @@ export default function RegistrationStepperModal() {
                   >
                     <div style={{ position: "relative" }}>
                       {/* Scrollable Columns Container */}
-                      <div style={{ maxHeight: "400px", overflowY: "auto", paddingRight: "8px" }}>
+                      <div style={{
+                        maxHeight: "400px",
+                        overflowY: "auto",
+                        paddingRight: "8px",
+                        scrollbarWidth: "none", /* Firefox */
+                        msOverflowStyle: "none", /* IE and Edge */
+                      }}
+                      className="hide-scrollbar"
+                      >
                         {/* Fixed Add Column Button - positioned at top of scrollable area */}
                         <div style={{
                           position: "sticky",

--- a/client/components/registration/registration.tsx
+++ b/client/components/registration/registration.tsx
@@ -102,16 +102,36 @@ interface OrganizationData {
 }
 
 export default function RegistrationStepperModal() {
-  // Enhanced CSS for smooth scrolling without visible scrollbar
+  // Enhanced CSS for smooth scrolling with internal scrollbar only
   const enhancedScrollStyle = `
+    /* Hide external scrollbars */
+    body {
+      overflow: hidden;
+    }
+
+    /* Internal scrollbar styling */
     .smooth-scroll-container {
       scroll-behavior: smooth;
-      scrollbar-width: none; /* Firefox */
-      -ms-overflow-style: none; /* IE and Edge */
+      scrollbar-width: thin;
+      scrollbar-color: #e5e7eb transparent;
     }
 
     .smooth-scroll-container::-webkit-scrollbar {
-      display: none; /* Chrome, Safari, Opera */
+      width: 6px;
+    }
+
+    .smooth-scroll-container::-webkit-scrollbar-track {
+      background: transparent;
+    }
+
+    .smooth-scroll-container::-webkit-scrollbar-thumb {
+      background: #e5e7eb;
+      border-radius: 3px;
+      transition: background 0.2s ease;
+    }
+
+    .smooth-scroll-container::-webkit-scrollbar-thumb:hover {
+      background: #d1d5db;
     }
 
     .column-card {
@@ -472,9 +492,9 @@ export default function RegistrationStepperModal() {
                     <div style={{ position: "relative" }}>
                       {/* Enhanced Scrollable Columns Container */}
                       <div style={{
-                        maxHeight: "450px",
+                        maxHeight: "400px",
                         overflowY: "auto",
-                        padding: "0 12px 8px 0",
+                        padding: "0 8px 8px 0",
                         background: "linear-gradient(to bottom, #f8fafc 0%, #ffffff 100%)",
                         borderRadius: "8px",
                         border: "1px solid #f1f5f9"

--- a/client/components/registration/registration.tsx
+++ b/client/components/registration/registration.tsx
@@ -102,10 +102,61 @@ interface OrganizationData {
 }
 
 export default function RegistrationStepperModal() {
-  // CSS to hide scrollbar
-  const hideScrollbarStyle = `
-    .hide-scrollbar::-webkit-scrollbar {
-      display: none;
+  // Enhanced CSS for smooth scrolling and attractive design
+  const enhancedScrollStyle = `
+    .smooth-scroll-container {
+      scroll-behavior: smooth;
+      scrollbar-width: thin;
+      scrollbar-color: #e5e7eb transparent;
+    }
+
+    .smooth-scroll-container::-webkit-scrollbar {
+      width: 4px;
+    }
+
+    .smooth-scroll-container::-webkit-scrollbar-track {
+      background: transparent;
+    }
+
+    .smooth-scroll-container::-webkit-scrollbar-thumb {
+      background: #e5e7eb;
+      border-radius: 2px;
+      transition: background 0.2s ease;
+    }
+
+    .smooth-scroll-container::-webkit-scrollbar-thumb:hover {
+      background: #d1d5db;
+    }
+
+    .column-card {
+      transition: all 0.2s ease;
+      transform: translateY(0);
+    }
+
+    .column-card:hover {
+      transform: translateY(-2px);
+      box-shadow: 0 8px 25px -8px rgba(0, 0, 0, 0.15);
+    }
+
+    .sticky-header {
+      backdrop-filter: blur(8px);
+      background: rgba(255, 255, 255, 0.95);
+      transition: all 0.2s ease;
+    }
+
+    @keyframes fadeInUp {
+      from {
+        opacity: 0;
+        transform: translateY(20px);
+      }
+      to {
+        opacity: 1;
+        transform: translateY(0);
+      }
+    }
+
+    .animate-fade-in {
+      animation: fadeInUp 0.3s ease-out;
     }
   `;
 
@@ -243,7 +294,7 @@ export default function RegistrationStepperModal() {
 
   return (
     <>
-      <style dangerouslySetInnerHTML={{ __html: hideScrollbarStyle }} />
+      <style dangerouslySetInnerHTML={{ __html: enhancedScrollStyle }} />
       <Overlay>
       <ModalContainer>
         {isCompleted ? (
@@ -433,36 +484,47 @@ export default function RegistrationStepperModal() {
                     }}
                   >
                     <div style={{ position: "relative" }}>
-                      {/* Scrollable Columns Container */}
+                      {/* Enhanced Scrollable Columns Container */}
                       <div style={{
-                        maxHeight: "400px",
+                        maxHeight: "450px",
                         overflowY: "auto",
-                        paddingRight: "8px",
-                        scrollbarWidth: "none", /* Firefox */
-                        msOverflowStyle: "none", /* IE and Edge */
+                        padding: "0 12px 8px 0",
+                        background: "linear-gradient(to bottom, #f8fafc 0%, #ffffff 100%)",
+                        borderRadius: "8px",
+                        border: "1px solid #f1f5f9"
                       }}
-                      className="hide-scrollbar"
+                      className="smooth-scroll-container"
                       >
-                        {/* Fixed Add Column Button - positioned at top of scrollable area */}
+                        {/* Enhanced Sticky Add Column Button */}
                         <div style={{
                           position: "sticky",
                           top: 0,
                           zIndex: 50,
                           display: "flex",
                           justifyContent: "flex-end",
-                          backgroundColor: "white",
-                          paddingTop: "0px",
-                          paddingBottom: "12px",
-                          marginBottom: "12px",
-                          borderBottom: "1px solid #e5e7eb"
-                        }}>
+                          padding: "16px 8px 16px 0",
+                          marginBottom: "8px",
+                          borderBottom: "1px solid #e2e8f0",
+                          borderRadius: "8px 8px 0 0"
+                        }}
+                        className="sticky-header">
                           <Button variant="secondary" onClick={addColumn}>
                             <Plus size={16} />
                             Add Column
                           </Button>
                         </div>
                         {columns.map((column, index) => (
-                          <div key={column.id} style={{ marginBottom: "24px", padding: "20px", border: "1px solid #e5e7eb", borderRadius: "12px", backgroundColor: "#f9fafb" }}>
+                          <div key={column.id}
+                               className="column-card animate-fade-in"
+                               style={{
+                                 marginBottom: "20px",
+                                 padding: "24px",
+                                 border: "1px solid #e2e8f0",
+                                 borderRadius: "16px",
+                                 backgroundColor: "#ffffff",
+                                 boxShadow: "0 2px 8px -2px rgba(0, 0, 0, 0.08)",
+                                 position: "relative"
+                               }}>
                             <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: "16px" }}>
                               <h3 style={{ margin: 0, fontSize: "16px", fontWeight: "600", color: "#374151" }}>
                                 Column {index + 1}

--- a/client/components/registration/registration.tsx
+++ b/client/components/registration/registration.tsx
@@ -429,7 +429,7 @@ export default function RegistrationStepperModal() {
                         position: "sticky",
                         top: 0,
                         right: 0,
-                        zIndex: 10,
+                        zIndex: 50,
                         display: "flex",
                         justifyContent: "flex-end",
                         marginBottom: "16px",

--- a/client/components/registration/registration.tsx
+++ b/client/components/registration/registration.tsx
@@ -490,35 +490,31 @@ export default function RegistrationStepperModal() {
                     }}
                   >
                     <div style={{ position: "relative" }}>
+                      {/* Fixed Add Column Button - Outside scrollable area */}
+                      <div style={{
+                        display: "flex",
+                        justifyContent: "flex-end",
+                        padding: "0 0 12px 0",
+                        marginBottom: "8px",
+                        borderBottom: "1px solid #e2e8f0"
+                      }}>
+                        <Button variant="secondary" onClick={addColumn}>
+                          <Plus size={16} />
+                          Add Column
+                        </Button>
+                      </div>
+
                       {/* Enhanced Scrollable Columns Container */}
                       <div style={{
                         maxHeight: "400px",
                         overflowY: "auto",
-                        padding: "0 8px 0 0",
+                        padding: "16px 8px 0 0",
                         background: "linear-gradient(to bottom, #f8fafc 0%, #ffffff 100%)",
                         borderRadius: "8px",
                         border: "1px solid #f1f5f9"
                       }}
                       className="smooth-scroll-container"
                       >
-                        {/* Enhanced Sticky Add Column Button */}
-                        <div style={{
-                          position: "sticky",
-                          top: 0,
-                          zIndex: 50,
-                          display: "flex",
-                          justifyContent: "flex-end",
-                          padding: "16px 8px 16px 0",
-                          marginBottom: "8px",
-                          borderBottom: "1px solid #e2e8f0",
-                          borderRadius: "8px 8px 0 0"
-                        }}
-                        className="sticky-header">
-                          <Button variant="secondary" onClick={addColumn}>
-                            <Plus size={16} />
-                            Add Column
-                          </Button>
-                        </div>
                         {columns.map((column, index) => (
                           <div key={column.id}
                                className="column-card animate-fade-in"

--- a/client/components/registration/registration.tsx
+++ b/client/components/registration/registration.tsx
@@ -229,8 +229,10 @@ export default function RegistrationStepperModal() {
     organizationData.organizationName &&
     organizationData.organizationId &&
     organizationData.tablePrefix;
+
   const isStep2Valid =
-    columns.length > 0 && columns.every((col) => col.label && col.columnType);
+    columns.length > 0 &&
+    columns.every((col) => col.label && col.label.trim() !== '' && col.columnType && col.columnType.trim() !== '');
 
   return (
     <Overlay>

--- a/client/components/registration/registration.tsx
+++ b/client/components/registration/registration.tsx
@@ -128,6 +128,8 @@ export default function RegistrationStepperModal() {
     },
   ]);
 
+  const [expandedFilterId, setExpandedFilterId] = useState<string | null>(null);
+
   const steps = [
     {
       id: 1,
@@ -169,6 +171,8 @@ export default function RegistrationStepperModal() {
       filterValues: [],
     };
     setColumns([...columns, newColumn]);
+    // Collapse all filters when adding a new column for smooth UX
+    setExpandedFilterId(null);
   };
 
   const updateColumn = (id: string, updates: Partial<ColumnConfig>) => {
@@ -420,7 +424,7 @@ export default function RegistrationStepperModal() {
                       opacity: { duration: 0.2 },
                     }}
                   >
-                    <div>
+                    <div style={{ maxHeight: "400px", overflowY: "auto", paddingRight: "8px" }}>
                       {columns.map((column, index) => (
                         <div key={column.id} style={{ marginBottom: "24px", padding: "20px", border: "1px solid #e5e7eb", borderRadius: "12px", backgroundColor: "#f9fafb" }}>
                           <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: "16px" }}>
@@ -456,6 +460,8 @@ export default function RegistrationStepperModal() {
                             columnTypes={columnTypes}
                             onConfigChange={(config) => updateColumn(column.id, config)}
                             isEdit={false}
+                            isFilterExpanded={expandedFilterId === column.id}
+                            onFilterToggle={() => setExpandedFilterId(expandedFilterId === column.id ? null : column.id)}
                           />
                         </div>
                       ))}

--- a/client/components/registration/registration.tsx
+++ b/client/components/registration/registration.tsx
@@ -478,6 +478,7 @@ export default function RegistrationStepperModal() {
                               columnTypes={columnTypes}
                               onConfigChange={(config) => updateColumn(column.id, config)}
                               isEdit={false}
+                              columnId={column.id}
                             />
                           </div>
                         ))}

--- a/client/components/registration/registration.tsx
+++ b/client/components/registration/registration.tsx
@@ -173,7 +173,6 @@ export default function RegistrationStepperModal() {
   };
 
   const updateColumn = (id: string, updates: Partial<ColumnConfig>) => {
-    console.log('updateColumn called:', { id, updates });
     setColumns(
       columns.map((col) => (col.id === id ? { ...col, ...updates } : col))
     );

--- a/client/components/registration/registration.tsx
+++ b/client/components/registration/registration.tsx
@@ -128,7 +128,6 @@ export default function RegistrationStepperModal() {
     },
   ]);
 
-  const [expandedFilterId, setExpandedFilterId] = useState<string | null>(null);
 
   const steps = [
     {
@@ -171,8 +170,6 @@ export default function RegistrationStepperModal() {
       filterValues: [],
     };
     setColumns([...columns, newColumn]);
-    // Collapse all filters when adding a new column for smooth UX
-    setExpandedFilterId(null);
   };
 
   const updateColumn = (id: string, updates: Partial<ColumnConfig>) => {
@@ -424,53 +421,66 @@ export default function RegistrationStepperModal() {
                       opacity: { duration: 0.2 },
                     }}
                   >
-                    <div style={{ maxHeight: "400px", overflowY: "auto", paddingRight: "8px" }}>
-                      {columns.map((column, index) => (
-                        <div key={column.id} style={{ marginBottom: "24px", padding: "20px", border: "1px solid #e5e7eb", borderRadius: "12px", backgroundColor: "#f9fafb" }}>
-                          <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: "16px" }}>
-                            <h3 style={{ margin: 0, fontSize: "16px", fontWeight: "600", color: "#374151" }}>
-                              Column {index + 1}
-                            </h3>
-                            {columns.length > 1 && (
-                              <button
-                                onClick={() => removeColumn(column.id)}
-                                style={{
-                                  background: "none",
-                                  border: "none",
-                                  color: "#ef4444",
-                                  cursor: "pointer",
-                                  padding: "4px",
-                                  borderRadius: "4px"
-                                }}
-                              >
-                                <X size={16} />
-                              </button>
-                            )}
-                          </div>
-                          <ColumnConfigForm
-                            initialConfig={{
-                              label: column.label,
-                              columnName: column.columnName,
-                              columnType: column.columnType,
-                              filterable: column.filterable,
-                              hidden: column.hidden,
-                              searchable: column.searchable,
-                              filterValues: column.filterValues,
-                            }}
-                            columnTypes={columnTypes}
-                            onConfigChange={(config) => updateColumn(column.id, config)}
-                            isEdit={false}
-                            isFilterExpanded={expandedFilterId === column.id}
-                            onFilterToggle={() => setExpandedFilterId(expandedFilterId === column.id ? null : column.id)}
-                          />
-                        </div>
-                      ))}
-
-                      <div style={{ marginTop: "1.5rem" }}>
+                    <div style={{ position: "relative" }}>
+                      {/* Fixed Add Column Button */}
+                      <div style={{
+                        position: "sticky",
+                        top: 0,
+                        right: 0,
+                        zIndex: 10,
+                        display: "flex",
+                        justifyContent: "flex-end",
+                        marginBottom: "16px",
+                        backgroundColor: "white",
+                        paddingBottom: "8px",
+                        borderBottom: "1px solid #e5e7eb"
+                      }}>
                         <Button variant="secondary" onClick={addColumn}>
                           <Plus size={16} />
                           Add Column
                         </Button>
+                      </div>
+
+                      {/* Scrollable Columns Container */}
+                      <div style={{ maxHeight: "400px", overflowY: "auto", paddingRight: "8px" }}>
+                        {columns.map((column, index) => (
+                          <div key={column.id} style={{ marginBottom: "24px", padding: "20px", border: "1px solid #e5e7eb", borderRadius: "12px", backgroundColor: "#f9fafb" }}>
+                            <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: "16px" }}>
+                              <h3 style={{ margin: 0, fontSize: "16px", fontWeight: "600", color: "#374151" }}>
+                                Column {index + 1}
+                              </h3>
+                              {columns.length > 1 && (
+                                <button
+                                  onClick={() => removeColumn(column.id)}
+                                  style={{
+                                    background: "none",
+                                    border: "none",
+                                    color: "#ef4444",
+                                    cursor: "pointer",
+                                    padding: "4px",
+                                    borderRadius: "4px"
+                                  }}
+                                >
+                                  <X size={16} />
+                                </button>
+                              )}
+                            </div>
+                            <ColumnConfigForm
+                              initialConfig={{
+                                label: column.label,
+                                columnName: column.columnName,
+                                columnType: column.columnType,
+                                filterable: column.filterable,
+                                hidden: column.hidden,
+                                searchable: column.searchable,
+                                filterValues: column.filterValues,
+                              }}
+                              columnTypes={columnTypes}
+                              onConfigChange={(config) => updateColumn(column.id, config)}
+                              isEdit={false}
+                            />
+                          </div>
+                        ))}
                       </div>
                     </div>
                   </motion.div>

--- a/client/components/registration/registration.tsx
+++ b/client/components/registration/registration.tsx
@@ -432,9 +432,9 @@ export default function RegistrationStepperModal() {
                         zIndex: 50,
                         display: "flex",
                         justifyContent: "flex-end",
-                        marginBottom: "16px",
+                        marginBottom: "8px",
                         backgroundColor: "white",
-                        paddingBottom: "8px",
+                        paddingBottom: "4px",
                         borderBottom: "1px solid #e5e7eb"
                       }}>
                         <Button variant="secondary" onClick={addColumn}>

--- a/client/components/registration/registration.tsx
+++ b/client/components/registration/registration.tsx
@@ -424,27 +424,26 @@ export default function RegistrationStepperModal() {
                     }}
                   >
                     <div style={{ position: "relative" }}>
-                      {/* Fixed Add Column Button */}
-                      <div style={{
-                        position: "sticky",
-                        top: 0,
-                        right: 0,
-                        zIndex: 50,
-                        display: "flex",
-                        justifyContent: "flex-end",
-                        marginBottom: "8px",
-                        backgroundColor: "white",
-                        paddingBottom: "4px",
-                        borderBottom: "1px solid #e5e7eb"
-                      }}>
-                        <Button variant="secondary" onClick={addColumn}>
-                          <Plus size={16} />
-                          Add Column
-                        </Button>
-                      </div>
-
                       {/* Scrollable Columns Container */}
                       <div style={{ maxHeight: "400px", overflowY: "auto", paddingRight: "8px" }}>
+                        {/* Fixed Add Column Button - positioned at top of scrollable area */}
+                        <div style={{
+                          position: "sticky",
+                          top: 0,
+                          zIndex: 50,
+                          display: "flex",
+                          justifyContent: "flex-end",
+                          backgroundColor: "white",
+                          paddingTop: "0px",
+                          paddingBottom: "12px",
+                          marginBottom: "12px",
+                          borderBottom: "1px solid #e5e7eb"
+                        }}>
+                          <Button variant="secondary" onClick={addColumn}>
+                            <Plus size={16} />
+                            Add Column
+                          </Button>
+                        </div>
                         {columns.map((column, index) => (
                           <div key={column.id} style={{ marginBottom: "24px", padding: "20px", border: "1px solid #e5e7eb", borderRadius: "12px", backgroundColor: "#f9fafb" }}>
                             <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: "16px" }}>

--- a/client/components/registration/registration.tsx
+++ b/client/components/registration/registration.tsx
@@ -234,6 +234,17 @@ export default function RegistrationStepperModal() {
     columns.length > 0 &&
     columns.every((col) => col.label && col.label.trim() !== '' && col.columnType && col.columnType.trim() !== '');
 
+  // Debug logging
+  console.log('Columns state:', columns);
+  console.log('isStep2Valid:', isStep2Valid);
+  console.log('Column validation details:', columns.map(col => ({
+    id: col.id,
+    label: col.label,
+    labelValid: col.label && col.label.trim() !== '',
+    columnType: col.columnType,
+    typeValid: col.columnType && col.columnType.trim() !== ''
+  })));
+
   return (
     <Overlay>
       <ModalContainer>

--- a/client/components/registration/style.ts
+++ b/client/components/registration/style.ts
@@ -22,6 +22,8 @@ export const ModalContainer = styled.div`
   max-height: 90vh;
   overflow: hidden;
   position: relative;
+  display: flex;
+  flex-direction: column;
 `;
 
 export const ModalHeader = styled.div`
@@ -195,6 +197,9 @@ export const ProgressLine = styled.div<{ isCompleted: boolean }>`
 
 export const Content = styled.div`
   padding: 1.5rem;
+  flex: 1;
+  overflow-y: auto;
+  min-height: 0;
 `;
 
 export const FormContainer = styled.div`
@@ -333,6 +338,7 @@ export const Footer = styled.div`
   display: flex;
   align-items: center;
   justify-content: space-between;
+  flex-shrink: 0;
 `;
 
 export const CompletionContainer = styled.div`

--- a/client/components/registration/style.ts
+++ b/client/components/registration/style.ts
@@ -1,5 +1,5 @@
-import styled from '@emotion/styled';
-import { css } from '@emotion/react';
+import styled from "@emotion/styled";
+import { css } from "@emotion/react";
 
 // Registration Modal Styles
 export const Overlay = styled.div`
@@ -99,7 +99,10 @@ export const StepContainer = styled.div`
   align-items: center;
 `;
 
-export const StepCircle = styled.div<{ isActive: boolean; isCompleted: boolean }>`
+export const StepCircle = styled.div<{
+  isActive: boolean;
+  isCompleted: boolean;
+}>`
   width: 2.5rem;
   height: 2.5rem;
   border-radius: 50%;
@@ -111,46 +114,61 @@ export const StepCircle = styled.div<{ isActive: boolean; isCompleted: boolean }
   position: relative;
   overflow: hidden;
 
-  ${props => props.isCompleted && css`
-    background-color: #2563eb;
-    border-color: #2563eb;
-    color: white;
-    transform: scale(1.05);
-    box-shadow: 0 4px 12px rgba(37, 99, 235, 0.3);
-  `}
+  ${(props) =>
+    props.isCompleted &&
+    css`
+      background-color: #2563eb;
+      border-color: #2563eb;
+      color: white;
+      transform: scale(1.05);
+      box-shadow: 0 4px 12px rgba(37, 99, 235, 0.3);
+    `}
 
-  ${props => props.isActive && !props.isCompleted && css`
-    background-color: #eff6ff;
-    border-color: #2563eb;
-    color: #2563eb;
-    transform: scale(1.1);
-    box-shadow: 0 4px 12px rgba(37, 99, 235, 0.2);
-  `}
+  ${(props) =>
+    props.isActive &&
+    !props.isCompleted &&
+    css`
+      background-color: #eff6ff;
+      border-color: #2563eb;
+      color: #2563eb;
+      transform: scale(1.1);
+      box-shadow: 0 4px 12px rgba(37, 99, 235, 0.2);
+    `}
 
-  ${props => !props.isActive && !props.isCompleted && css`
-    background-color: white;
-    border-color: #d1d5db;
-    color: #9ca3af;
-    transform: scale(1);
-  `}
+  ${(props) =>
+    !props.isActive &&
+    !props.isCompleted &&
+    css`
+      background-color: white;
+      border-color: #d1d5db;
+      color: #9ca3af;
+      transform: scale(1);
+    `}
 
   &::before {
-    content: '';
+    content: "";
     position: absolute;
     top: 0;
     left: 0;
     right: 0;
     bottom: 0;
-    background: linear-gradient(45deg, transparent 30%, rgba(255,255,255,0.5) 50%, transparent 70%);
+    background: linear-gradient(
+      45deg,
+      transparent 30%,
+      rgba(255, 255, 255, 0.5) 50%,
+      transparent 70%
+    );
     transform: translateX(-100%);
     transition: transform 0.6s;
   }
 
-  ${props => (props.isActive || props.isCompleted) && css`
-    &::before {
-      transform: translateX(100%);
-    }
-  `}
+  ${(props) =>
+    (props.isActive || props.isCompleted) &&
+    css`
+      &::before {
+        transform: translateX(100%);
+      }
+    `}
 `;
 
 export const StepInfo = styled.div`
@@ -162,7 +180,8 @@ export const StepTitle = styled.p<{ isActive: boolean; isCompleted: boolean }>`
   font-size: 0.875rem;
   font-weight: 500;
   margin: 0;
-  color: ${props => (props.isActive || props.isCompleted) ? '#111827' : '#6b7280'};
+  color: ${(props) =>
+    props.isActive || props.isCompleted ? "#111827" : "#6b7280"};
 `;
 
 export const StepDescription = styled.p`
@@ -183,12 +202,12 @@ export const ProgressLine = styled.div<{ isCompleted: boolean }>`
   position: relative;
 
   &::after {
-    content: '';
+    content: "";
     position: absolute;
     top: 0;
     left: 0;
     height: 100%;
-    width: ${props => props.isCompleted ? '100%' : '0%'};
+    width: ${(props) => (props.isCompleted ? "100%" : "0%")};
     background-color: #2563eb;
     border-radius: 2px;
     transition: width 0.8s cubic-bezier(0.4, 0, 0.2, 1);
@@ -267,7 +286,10 @@ export const HelpText = styled.p`
   margin: 0;
 `;
 
-export const Button = styled.button<{ variant?: 'primary' | 'secondary' | 'ghost'; disabled?: boolean }>`
+export const Button = styled.button<{
+  variant?: "primary" | "secondary" | "ghost";
+  disabled?: boolean;
+}>`
   padding: 0.75rem 1.5rem;
   border-radius: 0.5rem;
   font-size: 0.875rem;
@@ -281,54 +303,62 @@ export const Button = styled.button<{ variant?: 'primary' | 'secondary' | 'ghost
   position: relative;
   overflow: hidden;
 
-  ${props => props.variant === 'primary' && css`
-    background-color: #2563eb;
-    color: white;
+  ${(props) =>
+    props.variant === "primary" &&
+    css`
+      background-color: #2563eb;
+      color: white;
 
-    &:hover:not(:disabled) {
-      background-color: #1d4ed8;
-      transform: translateY(-1px);
-      box-shadow: 0 4px 12px rgba(37, 99, 235, 0.4);
-    }
+      &:hover:not(:disabled) {
+        background-color: #1d4ed8;
+        transform: translateY(-1px);
+        box-shadow: 0 4px 12px rgba(37, 99, 235, 0.4);
+      }
 
-    &:active:not(:disabled) {
-      transform: translateY(0);
-    }
-  `}
+      &:active:not(:disabled) {
+        transform: translateY(0);
+      }
+    `}
 
-  ${props => props.variant === 'secondary' && css`
-    background-color: white;
-    color: #374151;
-    border: 1px solid #d1d5db;
+  ${(props) =>
+    props.variant === "secondary" &&
+    css`
+      background-color: white;
+      color: #374151;
+      border: 1px solid #d1d5db;
 
-    &:hover:not(:disabled) {
-      background-color: #f9fafb;
-      border-color: #9ca3af;
-      transform: translateY(-1px);
-      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
-    }
+      &:hover:not(:disabled) {
+        background-color: #f9fafb;
+        border-color: #9ca3af;
+        transform: translateY(-1px);
+        box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+      }
 
-    &:active:not(:disabled) {
-      transform: translateY(0);
-    }
-  `}
+      &:active:not(:disabled) {
+        transform: translateY(0);
+      }
+    `}
 
-  ${props => props.variant === 'ghost' && css`
-    background: none;
-    color: #6b7280;
+  ${(props) =>
+    props.variant === "ghost" &&
+    css`
+      background: none;
+      color: #6b7280;
 
-    &:hover:not(:disabled) {
-      color: #111827;
-      background-color: rgba(0, 0, 0, 0.05);
-    }
-  `}
+      &:hover:not(:disabled) {
+        color: #111827;
+        background-color: rgba(0, 0, 0, 0.05);
+      }
+    `}
 
-  ${props => props.disabled && css`
-    opacity: 0.5;
-    cursor: not-allowed;
-    transform: none !important;
-    box-shadow: none !important;
-  `}
+  ${(props) =>
+    props.disabled &&
+    css`
+      opacity: 0.5;
+      cursor: not-allowed;
+      transform: none !important;
+      box-shadow: none !important;
+    `}
 `;
 
 export const Footer = styled.div`


### PR DESCRIPTION
## Purpose

The user wanted to improve the column configuration interface by:
- Making only the "Add Column" button fixed while scrolling (not the entire div)
- Removing external scrollbars and keeping only internal scrolling
- Making scrolling smoother and more attractive
- Eliminating gaps after the last column that caused the add column button to hide
- Syncing internal and external scrollbars to prevent the add column button from hiding when scrolling to the end

## Code changes

- **Modal layout improvements**: Added flexbox layout to `ModalContainer` and made `Content` scrollable with `flex: 1` and `overflow-y: auto`
- **Unique form IDs**: Added `columnId` prop to `ColumnConfigForm` and `ColumnConfigRow` components to generate unique IDs for form elements, preventing conflicts between multiple column configurations
- **State management**: Updated `ColumnConfigForm` to only sync `initialConfig` when `columnId` changes, preventing user input from being overwritten
- **Code formatting**: Standardized quote usage from single to double quotes throughout the codebase
- **Toggle logic fix**: Improved the filterable toggle logic to properly handle state updates
- **Footer positioning**: Made footer non-scrollable with `flex-shrink: 0` to keep navigation buttons always visible

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1`

🔗 [Edit in Builder.io](https://builder.io/app/projects/7c942ac1a075425882fe113fac6b7c53/zen-space)

👀 [Preview Link](https://7c942ac1a075425882fe113fac6b7c53-zen-space.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>7c942ac1a075425882fe113fac6b7c53</projectId>-->
<!--<branchName>zen-space</branchName>-->